### PR TITLE
Maintenance Update

### DIFF
--- a/gentoo-vbox-builder.sh
+++ b/gentoo-vbox-builder.sh
@@ -307,6 +307,14 @@ eoutdent
 
 einfo "PHASE 2: Prepare Root..."
 
+# detect if target is systemd
+GENTOO_SYSTEMD="$(
+    (echo "$GENTOO_PROFILE" | grep -q 'systemd' \
+        || echo "$GENTOO_STAGE3" | grep -q 'systemd') \
+        && echo yes || echo no
+)"
+
+
 eindent
 
 cat "$SCRIPT_DIR/lib/elib.sh" \
@@ -329,6 +337,8 @@ cat "$SCRIPT_DIR/lib/elib.sh" \
         "CURL_OPTS=\"$CURL_OPTS\"" \
         "GENTOO_GPG_SERVER=\"$GENTOO_GPG_SERVER\"" \
         "GENTOO_GPG_KEYS=\"$GENTOO_GPG_KEYS\"" \
+        "GENTOO_PROFILE=\"$GENTOO_PROFILE\"" \
+        "GENTOO_SYSTEMD=\"$GENTOO_SYSTEMD\"" \
         "bash -s"
 
 eoutdent
@@ -355,6 +365,7 @@ cat "$SCRIPT_DIR/lib/elib.sh" \
         "GENTOO_ARCH=\"$GENTOO_STAGE3\"" \
         "GENTOO_STAGE3=\"$GENTOO_STAGE3\"" \
         "GENTOO_PROFILE=\"$GENTOO_PROFILE\"" \
+        "GENTOO_SYSTEMD=\"$GENTOO_SYSTEMD\"" \
         "chroot /mnt/gentoo bash -s"
 
 einfo "Rebooting..."

--- a/gentoo-vbox-builder.sh
+++ b/gentoo-vbox-builder.sh
@@ -17,7 +17,7 @@ source "$SCRIPT_DIR/lib/distfiles.sh"
 
 APP_NAME="gentoo-vbox-builder"
 APP_DESCRIPTION="Gentoo VirtualBox Image Builder"
-APP_VERSION="1.0.7"
+APP_VERSION="1.0.8"
 
 # Gentoo mirror.
 GENTOO_MIRROR="http://distfiles.gentoo.org"
@@ -45,13 +45,13 @@ GUEST_NAME=""
 GUEST_OS_TYPE=""
 
 # Configure virtual disk size for Gentoo.
-GUEST_DISK_SIZE="20480"
+GUEST_DISK_SIZE="10240"
 
 # Configure number of CPUs delegated to guest.
-GUEST_CPUS="2"
+GUEST_CPUS="4"
 
 # Configure memory size delegated to guest.
-GUEST_MEM_SIZE="1024"
+GUEST_MEM_SIZE="4096"
 
 # Guest hard disk filename.
 GUEST_DISK_FILENAME=""
@@ -72,10 +72,10 @@ USE_ADMINCD="off"
 TARGET_DISK="/dev/sda"
 
 # Boot partition size.
-PARTITION_BOOT_SIZE="100M"
+PARTITION_BOOT_SIZE="300M"
 
 # Swap partition size.
-PARTITION_SWAP_SIZE="1G"
+PARTITION_SWAP_SIZE="128M"
 
 # SSH public key to use.
 SSH_PUBLIC_KEY="$(cat "$HOME/.ssh/id_rsa.pub")"
@@ -378,6 +378,8 @@ eexec VBoxManage storageattach "$GUEST_NAME" \
     --port 0
 
 eoutdent
+
+
 
 einfo "Done at $(date)"
 

--- a/gentoo-vbox-builder.sh
+++ b/gentoo-vbox-builder.sh
@@ -45,10 +45,10 @@ GUEST_NAME=""
 GUEST_OS_TYPE=""
 
 # Configure virtual disk size for Gentoo.
-GUEST_DISK_SIZE="10240"
+GUEST_DISK_SIZE="20480"
 
 # Configure number of CPUs delegated to guest.
-GUEST_CPUS="4"
+GUEST_CPUS="2"
 
 # Configure memory size delegated to guest.
 GUEST_MEM_SIZE="4096"

--- a/gentoo-vbox-builder.sh
+++ b/gentoo-vbox-builder.sh
@@ -379,6 +379,8 @@ eexec VBoxManage storageattach "$GUEST_NAME" \
 
 eoutdent
 
+einfo "Pruning any old instance's known ssh fingerprints"
+ssh-keygen -R [localhost]:$HOST_SSH_PORT
 
 
 einfo "Done at $(date)"

--- a/gentoo-vbox-builder.sh
+++ b/gentoo-vbox-builder.sh
@@ -81,7 +81,7 @@ PARTITION_SWAP_SIZE="1G"
 SSH_PUBLIC_KEY="$(cat "$HOME/.ssh/id_rsa.pub")"
 
 # Set root password.
-ROOT_PASSWORD="Gentoo123"
+ROOT_PASSWORD="Gentoo.Built.123"
 
 # Curl default options.
 CURL_OPTS="--silent"

--- a/gentoo-vbox-builder.sh
+++ b/gentoo-vbox-builder.sh
@@ -246,6 +246,13 @@ GUEST_OS_TYPE="$([ "$GENTOO_ARCH" = "x86" ] && echo "Gentoo" || echo "Gentoo_64"
 # Use default VirtualBox naming convention for virtual disk files.
 GUEST_DISK_FILENAME="$HOME/VirtualBox VMs/$GUEST_NAME/$GUEST_NAME.vdi"
 
+# Detect if target profile is systemd
+GENTOO_SYSTEMD="$(
+    (echo "$GENTOO_PROFILE" | grep -q 'systemd' \
+        || echo "$GENTOO_STAGE3" | grep -q 'systemd') \
+        && echo yes || echo no
+)"
+
 elog_set_colors "$COLOR"
 
 ################################################################################
@@ -305,15 +312,9 @@ source "$SCRIPT_DIR/lib/phase1-prepare-instance.sh"
 
 eoutdent
 
+################################################################################
+
 einfo "PHASE 2: Prepare Root..."
-
-# detect if target is systemd
-GENTOO_SYSTEMD="$(
-    (echo "$GENTOO_PROFILE" | grep -q 'systemd' \
-        || echo "$GENTOO_STAGE3" | grep -q 'systemd') \
-        && echo yes || echo no
-)"
-
 
 eindent
 
@@ -343,6 +344,8 @@ cat "$SCRIPT_DIR/lib/elib.sh" \
 
 eoutdent
 
+################################################################################
+
 einfo "PHASE 3: Build Root..."
 
 eindent
@@ -367,6 +370,8 @@ cat "$SCRIPT_DIR/lib/elib.sh" \
         "GENTOO_PROFILE=\"$GENTOO_PROFILE\"" \
         "GENTOO_SYSTEMD=\"$GENTOO_SYSTEMD\"" \
         "chroot /mnt/gentoo bash -s"
+
+################################################################################
 
 einfo "Rebooting..."
 

--- a/lib/distfiles.sh
+++ b/lib/distfiles.sh
@@ -19,10 +19,10 @@ download_distfile_safe() {
 
     eexec curl $CURL_OPTS \
         -o "$file" "$url" \
-        -o "$file.DIGESTS.asc" "$url.DIGESTS.asc"
+        -o "$file.DIGESTS" "$url.DIGESTS"
 
     for hash in sha512 whirlpool; do
-        expected_hash="$(grep -i "$hash" -A 1 < "$file.DIGESTS.asc" \
+        expected_hash="$(grep -i "$hash" -A 1 < "$file.DIGESTS" \
             | grep -v '^[#-]' | grep -v '\.CONTENTS\.' | cut -d" " -f1)"
 
         if [ -n "$expected_hash" ]; then
@@ -50,6 +50,6 @@ download_distfile_safe() {
 
     eexec gpg --keyserver $GENTOO_GPG_SERVER --recv-keys $GENTOO_GPG_KEYS
 
-    eexec gpg --verify "$file.DIGESTS.asc" \
+    eexec gpg --verify "$file.DIGESTS" \
         || edie "GPG signature verification failed."
 }

--- a/lib/phase1-prepare-instance.sh
+++ b/lib/phase1-prepare-instance.sh
@@ -60,7 +60,7 @@ for VM in $RUNNING_VMS; do
 done
 
 einfo "Pruning any old instance's known ssh fingerprints"
-ssh-keygen -R localhost:$HOST_SSH_PORT
+ssh-keygen -R [localhost]:$HOST_SSH_PORT
 
 ################################################################################
 

--- a/lib/phase1-prepare-instance.sh
+++ b/lib/phase1-prepare-instance.sh
@@ -59,8 +59,7 @@ for VM in $RUNNING_VMS; do
     fi
 done
 
-einfo "Pruning any old instance's known ssh fingerprints"
-ssh-keygen -R [localhost]:$HOST_SSH_PORT
+
 
 ################################################################################
 

--- a/lib/phase1-prepare-instance.sh
+++ b/lib/phase1-prepare-instance.sh
@@ -59,6 +59,9 @@ for VM in $RUNNING_VMS; do
     fi
 done
 
+einfo "Pruning any old instance's known ssh fingerprints"
+ssh-keygen -R localhost:$HOST_SSH_PORT
+
 ################################################################################
 
 if [ -z "$GENTOO_LIVECD_ISO" ]; then

--- a/lib/phase2-prepare-root.sh
+++ b/lib/phase2-prepare-root.sh
@@ -68,6 +68,73 @@ eexec cd /mnt/gentoo
 einfo "Installing stage3..."
 
 eindent
+einfo " - Profile is $GENTOO_PROFILE"
+
+unset STAGE3_PATH_PROFILE
+case "${GENTOO_PROFILE}" in
+	*musl*)
+		if [[ -n $STAGE3_PATH_PROFILE ]]; then
+			STAGE3_PATH_PROFILE="${STAGE3_PATH_PROFILE}-musl"
+		else
+			STAGE3_PATH_PROFILE="musl"
+		fi
+		;&
+	*clang*)
+		if [[ -n $STAGE3_PATH_PROFILE ]]; then
+			STAGE3_PATH_PROFILE="${STAGE3_PATH_PROFILE}-clang"
+		else
+			STAGE3_PATH_PROFILE="clang"
+		fi
+		;&
+	*hardened*)
+		if [[ -n $STAGE3_PATH_PROFILE ]]; then
+			STAGE3_PATH_PROFILE="${STAGE3_PATH_PROFILE}-hardened"
+		else
+			STAGE3_PATH_PROFILE="hardened"
+		fi
+		;&
+	*nomultilib*)
+		if [[ -n $STAGE3_PATH_PROFILE ]]; then
+			STAGE3_PATH_PROFILE="${STAGE3_PATH_PROFILE}-nomultilib"
+		else
+			STAGE3_PATH_PROFILE="nomultilib"
+		fi
+		;&
+	*selinux*)
+		if [[ -n $STAGE3_PATH_PROFILE ]]; then
+			STAGE3_PATH_PROFILE="${STAGE3_PATH_PROFILE}-selinux"
+		else
+			STAGE3_PATH_PROFILE="selinux"
+		fi
+		;&
+	*desktop*)
+		if [[ -n $STAGE3_PATH_PROFILE ]]; then
+			STAGE3_PATH_PROFILE="${STAGE3_PATH_PROFILE}-desktop"
+		else
+			STAGE3_PATH_PROFILE="desktop"
+		fi
+		;&
+esac
+
+
+if eon "$GENTOO_SYSTEMD"; then
+	if [[ $STAGE3_PATH_PROFILE ]]; then
+		STAGE3_PATH_PROFILE="${STAGE3_PATH_PROFILE}-systemd"
+	else
+		STAGE3_PATH_PROFILE="systemd"
+	fi
+else
+	if [[ $STAGE3_PATH_PROFILE ]]; then
+		STAGE3_PATH_PROFILE="${STAGE3_PATH_PROFILE}-openrc"
+	else
+		STAGE3_PATH_PROFILE="openrc"
+	fi
+fi
+
+
+echo "$STAGE3_PATH_PROFILE"
+
+
 
 STAGE3_PATH_URL="$GENTOO_MIRROR/releases/$GENTOO_ARCH/autobuilds/latest-stage3-$GENTOO_STAGE3.txt"
 STAGE3_PATH="$(curl -s "$STAGE3_PATH_URL" | grep -v "^#" | cut -d" " -f1)"

--- a/lib/phase2-prepare-root.sh
+++ b/lib/phase2-prepare-root.sh
@@ -68,7 +68,6 @@ eexec cd /mnt/gentoo
 einfo "Installing stage3..."
 
 eindent
-einfo " - Profile is $GENTOO_PROFILE"
 
 unset STAGE3_PATH_PROFILE
 case "${GENTOO_PROFILE}" in
@@ -132,11 +131,10 @@ else
 fi
 
 
-echo "$STAGE3_PATH_PROFILE"
+eecho "Specified Profile: $GENTOO_PROFILE"
+eecho "Download Profile:  $STAGE3_PATH_PROFILE"
 
-
-
-STAGE3_PATH_URL="$GENTOO_MIRROR/releases/$GENTOO_ARCH/autobuilds/latest-stage3-$GENTOO_STAGE3.txt"
+STAGE3_PATH_URL="$GENTOO_MIRROR/releases/$GENTOO_ARCH/autobuilds/latest-stage3-$GENTOO_STAGE3-$STAGE3_PATH_PROFILE.txt"
 STAGE3_PATH="$(curl -s "$STAGE3_PATH_URL" | grep -v "^#" | cut -d" " -f1)"
 STAGE3_URL="$GENTOO_MIRROR/releases/$GENTOO_ARCH/autobuilds/$STAGE3_PATH"
 STAGE3_FILE="$(basename "$STAGE3_URL")"

--- a/lib/phase3-build-root.sh
+++ b/lib/phase3-build-root.sh
@@ -14,13 +14,6 @@ set -e
 
 ################################################################################
 
-# detect if target is systemd
-GENTOO_SYSTEMD="$(
-    (echo "$GENTOO_PROFILE" | grep -q 'systemd' \
-        || echo "$GENTOO_STAGE3" | grep -q 'systemd') \
-        && echo yes || echo no
-)"
-
 # detect kernel config file that should be used for bootstrap
 KERNEL_CONFIG="$(find /etc/kernels -type f | head -n 1)"
 

--- a/lib/phase3-build-root.sh
+++ b/lib/phase3-build-root.sh
@@ -125,6 +125,9 @@ if eon "$GENTOO_SYSTEMD"; then
     KERNEL_CONFIG="$KERNEL_CONFIG.bootstrap"
 fi
 
+# Genkernel will fail if we do not have a /usr/src/linux symlink
+eexec eselect kernel set 1
+
 ################################################################################
 
 if eon "$USE_LIVECD_KERNEL" && eon "$GENTOO_SYSTEMD"; then
@@ -202,6 +205,9 @@ fi
 ################################################################################
 
 einfo "Configuring network..."
+
+# Network needs DHCP to come up
+eexec emerge $EMERGE_OPTS "net-misc/dhcpcd"
 
 if eoff "$GENTOO_SYSTEMD"; then
     eexec ln -s /etc/init.d/net.lo /etc/init.d/net.eth0


### PR DESCRIPTION
Thanks for building this script.  Here are some maintenance updates, mainly maintenance updates.  

- App Version updated to 1.0.8
- Update to Verification URLs to match gentoo mirrors.
- Update to Stage3 download to download the best stage option based on the selected profile.
- Update to add kernel symlink to ensure genkernel does not fail
- Update to Prune any old instance's known ssh fingerprints
- Update to build a DHCP client so networking does not fail to start on reboot
- Systemd check moved to the main script and imported into the multiple phases. 
- Default Memory to 4 GB as some packages can fail with lower memory
- Default Boot Size to 300M to handle multiple kernels 
- Default Swap reduced
- Default Root Password Complexity Added to match Gentoo's Current requirements.


