### PR TITLE
Feature & Maintenance PR

### DIFF
--- a/gentoo-vbox-builder.sh
+++ b/gentoo-vbox-builder.sh
@@ -111,6 +111,12 @@ KEEP_DOWNLOADS="off"
 # Disable Debug by default.
 ELOG_DEBUG="off"
 
+# Disable installing cron by default 
+INSTALL_CRON="off"
+
+# Disable installing a sys log by default
+INSTALL_SYSLOG="off"
+
 ################################################################################
 
 show_help() {
@@ -183,6 +189,12 @@ $(echo "$GENTOO_PROFILE_LIST" | sed 's/^/          * /')
     --keep-downloads <bool>         (default is "$KEEP_DOWNLOADS")
         Enable or disable cleaning up files downloaded to /tmp on exit.
 
+    --install-cron <bool>           (default is "$INSTALL_CRON")
+        Enable or disable installing a cron daemon (cronie)
+
+    --install-syslog <bool>         (default is "$INSTALL_SYSLOG")
+        Enable or disable installing a System logger (sysklogd)
+
     --version
         Show version.
 
@@ -216,6 +228,8 @@ opt_config "
     --color \
     --keep-downloads \
     --debug \
+    --install-cron \
+    --install-syslog \
 "
 
 opt_parse "$@"
@@ -246,6 +260,8 @@ OPT="$(opt_get "--use-admincd")";           [ -z "$OPT" ] || USE_ADMINCD="$OPT"
 OPT="$(opt_get "--color")";                 [ -z "$OPT" ] || COLOR="$OPT"
 OPT="$(opt_get "--keep-downloads")";        [ -z "$OPT" ] || KEEP_DOWNLOADS="$OPT"
 OPT="$(opt_get "--debug")";                 [ -z "$OPT" ] || ELOG_DEBUG="$OPT"
+OPT="$(opt_get "--install-cron")";          [ -z "$OPT" ] || INSTALL_CRON="$OPT"
+OPT="$(opt_get "--install-syslog")";        [ -z "$OPT" ] || INSTALL_SYSLOG="$OPT"
 
 
 # Autodetect Gentoo architecture based on profile name.
@@ -407,6 +423,8 @@ cat "$SCRIPT_DIR/lib/elib.sh" \
         "GENTOO_STAGE3=\"$GENTOO_STAGE3\"" \
         "GENTOO_PROFILE=\"$GENTOO_PROFILE\"" \
         "GENTOO_SYSTEMD=\"$GENTOO_SYSTEMD\"" \
+        "INSTALL_SYSLOG=\"$INSTALL_SYSLOG\"" \
+        "INSTALL_CRON=\"$INSTALL_CRON\"" \
         "chroot /mnt/gentoo bash -s"
 
 ################################################################################

--- a/gentoo-vbox-builder.sh
+++ b/gentoo-vbox-builder.sh
@@ -105,6 +105,9 @@ SSH_OPTS="-o ConnectTimeout=5
 # Enable color by default.
 COLOR="on"
 
+# Disable Debug by default.
+ELOG_DEBUG="off"
+
 ################################################################################
 
 show_help() {
@@ -205,6 +208,7 @@ opt_config "
     --use-livecd-kernel \
     --use-admincd \
     --color \
+    --debug \
 "
 
 opt_parse "$@"
@@ -233,6 +237,8 @@ OPT="$(opt_get "--root-password")";         [ -z "$OPT" ] || ROOT_PASSWORD="$OPT
 OPT="$(opt_get "--use-livecd-kernel")";     [ -z "$OPT" ] || USE_LIVECD_KERNEL="$OPT"
 OPT="$(opt_get "--use-admincd")";           [ -z "$OPT" ] || USE_ADMINCD="$OPT"
 OPT="$(opt_get "--color")";                 [ -z "$OPT" ] || COLOR="$OPT"
+OPT="$(opt_get "--debug")";                 [ -z "$OPT" ] || ELOG_DEBUG="$OPT"
+
 
 # Autodetect Gentoo architecture based on profile name.
 GENTOO_ARCH="$(echo "$GENTOO_STAGE3" | grep -q '^\(amd64\|x32\)' && echo "amd64" || echo "x86")"
@@ -295,6 +301,8 @@ if ! command -v gpg &> /dev/null; then
     edie "GPG is not installed."
 fi
 
+edebug "Debug Messages are enabled"
+
 ################################################################################
 # PHASE 1: Prepare Instance...
 
@@ -340,6 +348,7 @@ cat "$SCRIPT_DIR/lib/elib.sh" \
         "ELOG_COLOR_ERROR=\"$ELOG_COLOR_ERROR\"" \
         "ELOG_COLOR_QUOTE=\"$ELOG_COLOR_QUOTE\"" \
         "ELOG_COLOR_RESET=\"$ELOG_COLOR_RESET\"" \
+        "ELOG_DEBUG=\"$ELOG_DEBUG\"" \
         "GENTOO_MIRROR=\"$GENTOO_MIRROR\"" \
         "GENTOO_STAGE3=\"$GENTOO_STAGE3\"" \
         "GENTOO_ARCH=\"$GENTOO_ARCH\"" \
@@ -371,6 +380,7 @@ cat "$SCRIPT_DIR/lib/elib.sh" \
         "ELOG_COLOR_ERROR=\"$ELOG_COLOR_ERROR\"" \
         "ELOG_COLOR_QUOTE=\"$ELOG_COLOR_QUOTE\"" \
         "ELOG_COLOR_RESET=\"$ELOG_COLOR_RESET\"" \
+        "ELOG_DEBUG=\"$ELOG_DEBUG\"" \
         "USE_LIVECD_KERNEL=\"$USE_LIVECD_KERNEL\"" \
         "TARGET_DISK=\"$TARGET_DISK\"" \
         "SSH_PUBLIC_KEY=\"$SSH_PUBLIC_KEY\"" \

--- a/gentoo-vbox-builder.sh
+++ b/gentoo-vbox-builder.sh
@@ -27,7 +27,7 @@ GENTOO_GPG_SERVER="${GENTOO_GPG_SERVER:-hkps://keys.gentoo.org}"
 GENTOO_GPG_KEYS="$(cat "$SCRIPT_DIR/gentoo-gpg-keys.txt" | grep -v '^#')"
 
 # Gentoo stage3.
-GENTOO_STAGE3="amd64"
+GENTOO_STAGE3="amd64-openrc"
 
 # Gentoo profile. Blank indicates that stage3 default profile should be used.
 GENTOO_PROFILE=""

--- a/gentoo-vbox-builder.sh
+++ b/gentoo-vbox-builder.sh
@@ -17,7 +17,7 @@ source "$SCRIPT_DIR/lib/distfiles.sh"
 
 APP_NAME="gentoo-vbox-builder"
 APP_DESCRIPTION="Gentoo VirtualBox Image Builder"
-APP_VERSION="1.0.8"
+APP_VERSION="1.0.9"
 
 # Gentoo mirror.
 GENTOO_MIRROR="http://distfiles.gentoo.org"

--- a/gentoo-vbox-builder.sh
+++ b/gentoo-vbox-builder.sh
@@ -283,8 +283,20 @@ trap 'handle_exit' EXIT
 trap 'handle_error ${LINENO}' ERR
 
 ################################################################################
+# Initialization & Dependency check
 
 einfo "$APP_DESCRIPTION $APP_VERSION"
+
+if ! command -v VBoxManage &> /dev/null; then
+    edie "VBoxManage is not installed, please install/reinstall VirtualBox"
+fi
+
+if ! command -v gpg &> /dev/null; then
+    edie "GPG is not installed."
+fi
+
+################################################################################
+# PHASE 1: Prepare Instance...
 
 einfo "The following parameters will be used:"
 

--- a/lib/distfiles.sh
+++ b/lib/distfiles.sh
@@ -17,9 +17,14 @@ download_distfile_safe() {
     local hash
     local hash_verified=0
 
-    eexec curl $CURL_OPTS \
-        -o "$file" "$url" \
+    if [[ -f "$file" && -f "$file.DIGESTS" ]]; then 
+        edebug "Found $file and $file.DIGESTS, skiping download"
+    else
+        edebug "Did not find both $file and $file.DIGESTS, downloading now."
+        eexec curl $CURL_OPTS \
+            -o "$file" "$url" \
         -o "$file.DIGESTS" "$url.DIGESTS"
+    fi
 
     for hash in sha512 whirlpool; do
         expected_hash="$(grep -i "$hash" -A 1 < "$file.DIGESTS" \
@@ -34,6 +39,8 @@ download_distfile_safe() {
                 eerror "$hash hash verification failed."
                 eerror "Expected $hash: $expected_hash"
                 eerror "Actual $hash: $actual_hash"
+                edebug "Removingto force download on next run"
+                download_distfile_cleanup
                 exit 1
             else
                 hash_verified=1
@@ -53,3 +60,16 @@ download_distfile_safe() {
     eexec gpg --verify "$file.DIGESTS" \
         || edie "GPG signature verification failed."
 }
+
+download_distfile_cleanup() {
+    if [ -n "$GENTOO_LIVECD_TMP" ] && [ -e "$GENTOO_LIVECD_TMP" ]; then
+        edebug "Removing $GENTOO_LIVECD_TMP"
+        rm  "$GENTOO_LIVECD_TMP"
+    fi
+
+    if [ -n "$GUEST_INIT_FILE" ] && [ -e "$GUEST_INIT_FILE" ]; then
+        edebug "Removing $GUEST_INIT_FILE"
+        rm "$GUEST_INIT_FILE"
+    fi
+}
+

--- a/lib/distfiles.sh
+++ b/lib/distfiles.sh
@@ -12,6 +12,8 @@ download_distfile_safe() {
     local url="$1"
     local file="$2"
 
+    edebug "Download URL: $url"
+    edebug "Download File: $file"
     local expected_hash
     local actual_hash
     local hash
@@ -39,7 +41,7 @@ download_distfile_safe() {
                 eerror "$hash hash verification failed."
                 eerror "Expected $hash: $expected_hash"
                 eerror "Actual $hash: $actual_hash"
-                edebug "Removingto force download on next run"
+                edebug "Cleaning up faulty distfiles ..."
                 download_distfile_cleanup
                 exit 1
             else

--- a/lib/elib.sh
+++ b/lib/elib.sh
@@ -11,6 +11,7 @@ COLOR_RESET=$'\033[00m'
 # global ELOG_COLOR_ERROR
 # global ELOG_COLOR_QUOTE
 # global ELOG_COLOR_RESET
+# global ELOF_DEBUG
 
 eon() {
     echo "$1" | grep -q -i '^\(1\|yes\|true\|on\)$'
@@ -147,4 +148,10 @@ eexec() {
     rm "$output_file"
 
     return $error_code
+}
+
+edebug() {
+    if eon "$ELOG_DEBUG"; then
+        echo " ${ELOG_COLOR_OK}D${ELOG_COLOR_RESET}${ELOG_INDENT}" "$@"
+    fi
 }

--- a/lib/elib.sh
+++ b/lib/elib.sh
@@ -155,3 +155,4 @@ edebug() {
         echo " ${ELOG_COLOR_OK}D${ELOG_COLOR_RESET}${ELOG_INDENT}" "$@"
     fi
 }
+

--- a/lib/phase1-prepare-instance.sh
+++ b/lib/phase1-prepare-instance.sh
@@ -162,8 +162,9 @@ sleep 10
 
 einfo "Booting Gentoo from LiveCD..."
 
-eexec VBoxManage controlvm "$GUEST_NAME" \
-    keyboardputstring $'gentoo nokeymap vga=786\n'
+# Commented out since Gentoo LiveCD now uses grub instead of syslinux
+#eexec VBoxManage controlvm "$GUEST_NAME" \
+#    keyboardputstring $'gentoo nokeymap vga=786\n'
 
 sleep 60
 

--- a/lib/phase1-prepare-instance.sh
+++ b/lib/phase1-prepare-instance.sh
@@ -23,6 +23,8 @@
 
 set -e
 
+edebug "Debug Messages sucessfully enabled in Phase 1"
+
 ################################################################################
 
 if VBoxManage list runningvms | grep -q '^"'"$GUEST_NAME"'"'; then

--- a/lib/phase2-prepare-root.sh
+++ b/lib/phase2-prepare-root.sh
@@ -71,77 +71,10 @@ einfo "Installing stage3..."
 
 eindent
 
-unset STAGE3_PATH_PROFILE
-case "${GENTOO_PROFILE}" in
-	*musl*)
-		if [[ -n $STAGE3_PATH_PROFILE ]]; then
-			STAGE3_PATH_PROFILE="${STAGE3_PATH_PROFILE}-musl"
-		else
-			STAGE3_PATH_PROFILE="musl"
-		fi
-		;&
-	*clang*)
-		if [[ -n $STAGE3_PATH_PROFILE ]]; then
-			STAGE3_PATH_PROFILE="${STAGE3_PATH_PROFILE}-clang"
-		else
-			STAGE3_PATH_PROFILE="clang"
-		fi
-		;&
-	*hardened*)
-		if [[ -n $STAGE3_PATH_PROFILE ]]; then
-			STAGE3_PATH_PROFILE="${STAGE3_PATH_PROFILE}-hardened"
-		else
-			STAGE3_PATH_PROFILE="hardened"
-		fi
-		;&
-	*nomultilib*)
-		if [[ -n $STAGE3_PATH_PROFILE ]]; then
-			STAGE3_PATH_PROFILE="${STAGE3_PATH_PROFILE}-nomultilib"
-		else
-			STAGE3_PATH_PROFILE="nomultilib"
-		fi
-		;&
-	*selinux*)
-		if [[ -n $STAGE3_PATH_PROFILE ]]; then
-			STAGE3_PATH_PROFILE="${STAGE3_PATH_PROFILE}-selinux"
-		else
-			STAGE3_PATH_PROFILE="selinux"
-		fi
-		;&
-	*desktop*)
-		if [[ -n $STAGE3_PATH_PROFILE ]]; then
-			STAGE3_PATH_PROFILE="${STAGE3_PATH_PROFILE}-desktop"
-		else
-			STAGE3_PATH_PROFILE="desktop"
-		fi
-		;&
-esac
-
-
-if eon "$GENTOO_SYSTEMD"; then
-	if [[ $STAGE3_PATH_PROFILE ]]; then
-		STAGE3_PATH_PROFILE="${STAGE3_PATH_PROFILE}-systemd"
-	else
-		STAGE3_PATH_PROFILE="systemd"
-	fi
-else
-	if [[ $STAGE3_PATH_PROFILE ]]; then
-		STAGE3_PATH_PROFILE="${STAGE3_PATH_PROFILE}-openrc"
-	else
-		STAGE3_PATH_PROFILE="openrc"
-	fi
-fi
-
-
-eecho "Specified Profile: $GENTOO_PROFILE"
-eecho "Download Profile:  $STAGE3_PATH_PROFILE"
-
-STAGE3_PATH_URL="$GENTOO_MIRROR/releases/$GENTOO_ARCH/autobuilds/latest-stage3-$GENTOO_STAGE3-$STAGE3_PATH_PROFILE.txt"
+STAGE3_PATH_URL="$GENTOO_MIRROR/releases/$GENTOO_ARCH/autobuilds/latest-stage3-$GENTOO_STAGE3.txt"
 STAGE3_PATH="$(curl -s "$STAGE3_PATH_URL" | grep -v "^#" | cut -d" " -f1)"
 STAGE3_URL="$GENTOO_MIRROR/releases/$GENTOO_ARCH/autobuilds/$STAGE3_PATH"
 STAGE3_FILE="$(basename "$STAGE3_URL")"
-
-einfo "Downloading: $STAGE3_URL ..."
 
 download_distfile_safe "$STAGE3_URL" "$STAGE3_FILE"
 

--- a/lib/phase2-prepare-root.sh
+++ b/lib/phase2-prepare-root.sh
@@ -15,12 +15,6 @@ edebug "Debug Messages sucessfully enabled in Phase 2"
 
 ################################################################################
 
-einfo "Synchronizing time..."
-
-eexec ntpd -gq
-
-################################################################################
-
 einfo "Preparing disk..."
 
 eindent

--- a/lib/phase2-prepare-root.sh
+++ b/lib/phase2-prepare-root.sh
@@ -11,6 +11,8 @@
 
 set -e
 
+edebug "Debug Messages sucessfully enabled in Phase 2"
+
 ################################################################################
 
 einfo "Synchronizing time..."

--- a/lib/phase3-build-root.sh
+++ b/lib/phase3-build-root.sh
@@ -12,6 +12,8 @@
 
 set -e
 
+edebug "Debug Messages sucessfully enabled in Phase 3"
+
 ################################################################################
 
 # detect kernel config file that should be used for bootstrap

--- a/lib/phase3-build-root.sh
+++ b/lib/phase3-build-root.sh
@@ -223,6 +223,25 @@ fi
 
 ################################################################################
 
+if eon $INSTALL_SYSLOG; then
+    if eoff "$GENTOO_SYSTEMD"; then
+        einfo "Installing system logger..."
+        eexec emerge $EMERGE_OPTS "app-admin/sysklogd"
+        eexec rc-update add sysklogd default
+    else
+        edebug "Skiping installing system logger, in preferance of systemd's built in one"
+    fi
+fi
+################################################################################
+
+if eon $INSTALL_CRON; then 
+    einfo "Installing Cron"
+    eexec emerge $EMERGE_OPTS "sys-process/cronie"
+    eexec rc-update add cronie
+fi 
+
+################################################################################
+
 if [ -z "$ROOT_PASSWORD" ]; then
     einfo "Removing root password..."
     eexec passwd -d -l root


### PR DESCRIPTION
**Features Added**
- [Added basic dependency for host tools](https://github.com/sormy/gentoo-vbox-builder/commit/a146b3da6bfd5cbc5fbe4516724b0014294bbaa0) - From a fresh MacOS install I think only VirtualBox and GPG(via homebrew) need to be installed. 
- [Added undocumented debug feature](https://github.com/sormy/gentoo-vbox-builder/commit/23d1ab253bdc4877839c95f462061717d0291410) - Debug output can be enabled with --debug on, edebug command added to elib.sh 
- [Added Feature to Keep Persistent ISO Downloads](https://github.com/sormy/gentoo-vbox-builder/commit/0b572582d8678c25fa827b16a2d34858fa0326f2) - When downloading with the option --keep-downloads on, downloaded files in /tmp will be left so they can be used for the next run. 
- [Added support for cronie and sysklogd](https://github.com/sormy/gentoo-vbox-builder/commit/cde06bb957e4adb3b289da38773c51ebdde2256c) - Added the ability to install cronie and sysklogd, both disabled by default 

**Fixes**
- [Gentoo LiveCD now uses grub instead of syslinux](https://github.com/sormy/gentoo-vbox-builder/commit/e19551f998c243ede1ecc909b13aae370ead0e23) - Due to this, passing the vga option caused grub to hang. Commenting that out for now works.  However, the sleep to attempt ssh may need to be extended due to the added grub delay. 
- [Removed initial workaround to get a stage to download](https://github.com/sormy/gentoo-vbox-builder/commit/b4c45e4da5904b6d2a706da703d87d4ad9861a28) - I had added a workaround to get a stage to download when first updating the script.  However, I found what I did not see before and can remove this workaround. 
